### PR TITLE
fix: auto mount after formatted.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-device-formatter (0.0.1.17) unstable; urgency=medium
+
+  * Auto mount after device been formatted.
+  * 
+
+ -- XuShitong <xushitong@uniontech.com>  Wed, 25 Dec 2024 15:14:40 +0800
+
 dde-device-formatter (0.0.1.16) unstable; urgency=medium
 
   * update baseline version to 0.0.1.16

--- a/view/mainwindow.cpp
+++ b/view/mainwindow.cpp
@@ -244,6 +244,10 @@ void MainWindow::onFormatingFinished(const bool &successful)
         m_comfirmButton->setText(tr("Done"));
         m_comfirmButton->setEnabled(true);
         m_pageStack->setCurrentWidget(m_finishPage);
+
+        QTimer::singleShot(0, this, [this] {
+            UDisksBlock(this->m_formatPath)->mount({});
+        });
     } else {
         if (!QFile::exists(m_formatPath)) {
             m_currentStep = RemovedWhenFormattingError;


### PR DESCRIPTION
In some file systems, path file attribute lookups will be delayed in
returning if you immediately enter a device that has just been
formatted. And because of this, some actions in context menu is disabled
due to the real read write permission is not obtained when context menu
triggered.
Auto mount after formatted, so that there could be a large interval user
first enter into device, and the permission attributes could be updated
correctly.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-296699.html
