### PR TITLE
chore: update translations

### DIFF
--- a/translations/dde-device-formatter.ts
+++ b/translations/dde-device-formatter.ts
@@ -49,37 +49,37 @@
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="213"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="218"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatting...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="244"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="254"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="255"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
         <translation>Your disk has been removed</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="258"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Failed to format the device</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="259"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Reformat</translation>
     </message>
@@ -95,17 +95,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="38"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>System Disk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="42"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Encrypted</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="44"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Volume</translation>
     </message>
@@ -113,17 +113,17 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="68"/>
+        <location filename="../main.cpp" line="80"/>
         <source>dde device formatter</source>
         <translation>dde device formatter</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="84"/>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Device does not exist</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="93"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>The device is read-only</translation>
     </message>

--- a/translations/dde-device-formatter_ady.ts
+++ b/translations/dde-device-formatter_ady.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ady">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_af.ts
+++ b/translations/dde-device-formatter_af.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="af">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Formaat is suksesvol</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Formaat van die skerm, asseblief wag...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Tipe</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Etiket</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Snel Formaat</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Formaat sal alle data op die skerm verwyder.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Formaat</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Voortgaan</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Formaat...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Doneer</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Verlaat</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>U skerm is verwijder</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Formaat van die toestel is geslaag</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Herformaat</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Sisteem Skerm</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Verklaar'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Volume'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde toestel formaatprogram</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Toestel bestaan nie</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Die toestel is slegs-lees</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Formaat sal alle data op hierdie skerm verwyder, is u seker dat u wil voortgaan? Dit kan nie herstel word nie.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_am_ET.ts
+++ b/translations/dde-device-formatter_am_ET.ts
@@ -1,95 +1,92 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="am_ET" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="am_ET">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>መረጃ ያስፈልጋለች</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>የዲስክ ማረጋገጫ ይካትታል፣ ደንበ ይጠብቅ</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>አይነት</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
-        <translation type="unfinished"/>
+        <translation>መደብ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>ፍላሽ ማረጋገጫ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>ማረጋገጫ የዲስክ ስለመረጃ ይሰርቅ</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
-        <translation type="unfinished"/>
+        <translation>ማረጋገጫ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>ይቀጥሉ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
-        <translation type="unfinished"/>
+        <translation>ማረጋገጫ...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation>አማራሽ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>ማቋረጫ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>ዲስክዎ ይተወለዱል</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>ዲች ማረጋገጫ የተሳሳተ ይመጣል</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
-        <translation type="unfinished"/>
+        <translation>መረጃ ማረጋገጫ</translation>
     </message>
 </context>
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>እሺ</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>የሰራተኛ መረጃ</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 የተስተካከሉ ይመጣል'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 መጠን</translation>
     </message>
@@ -115,26 +112,27 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde የዲች ማረጋገጫ አገልግሎት</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
-        <translation type="unfinished"/>
+        <translation>ዲች የሚገኛል</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="unfinished"/>
+        <translation>ዲች የማንበጃ ይመጣል</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>ማረጋገጫ የዲስክ ስለመረጃ ይሰርቅ፣ እርምጃ ይፈልጋሉ የማረጋገጫ ይቀጥሉ? ይተወለዱል የሚገኝም ይመጣል።</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_ar.ts
+++ b/translations/dde-device-formatter_ar.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ar" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>تمت التهيئة بنحاح</translation>
     </message>
@@ -10,78 +12,73 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>جاري تنسيق القرص، من فضلك انتظر...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
-        <translation type="unfinished"/>
+        <translation>النوع</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
-        <translation type="unfinished"/>
+        <translation>الاسم</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>تنسيق سريع</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>سيُحذف التنسيق جميع البيانات الموجودة على القرص.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
-        <translation type="unfinished"/>
+        <translation>تنسيق</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
-        <translation type="unfinished"/>
+        <translation>استمر</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
-        <translation type="unfinished"/>
+        <translation>جاري التنسيق...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>انتهى</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
-        <translation type="unfinished"/>
+        <translation>الخروج</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>تم إزالة قرصك</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>فشل في تنسيق الجهاز</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>إعادة التهيئة</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>موافق</translation>
     </message>
@@ -97,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>قرص النظام</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 مشفر'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 الحجم'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
-        <translation type="unfinished"/>
+        <translation>الجهاز غير موجود</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="unfinished"/>
+        <translation>الجهاز فقط للقراءة</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>سيُحذف تنسيق هذا القرص جميع البيانات الموجودة عليه، هل أنت متأكد من استمرارك؟ لا يمكن استعادة البيانات.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_ast.ts
+++ b/translations/dde-device-formatter_ast.ts
@@ -1,10 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ast" version="2.1">
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ast">
 <context>
     <name>FinishPage</name>
     <message>
         <location filename="../view/finishpage.cpp" line="42"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>Formato exitosu</translation>
     </message>
 </context>
 <context>
@@ -12,7 +12,7 @@
     <message>
         <location filename="../view/formatingpage.cpp" line="47"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Formatando el discu, por favor, espere...</translation>
     </message>
 </context>
 <context>
@@ -30,19 +30,18 @@
     <message>
         <location filename="../view/mainpage.cpp" line="131"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>Formato rápido</translation>
     </message>
     <message>
         <location filename="../view/mainpage.cpp" line="148"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>El formato eliminará todos los datos nel discu.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
         <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
         <source>Format</source>
         <translation>Formatiar</translation>
     </message>
@@ -69,12 +68,12 @@
     <message>
         <location filename="../view/mainwindow.cpp" line="198"/>
         <source>Your disk is removed when formatting</source>
-        <translation>Baleraráse&apos;l to discu al formatiar</translation>
+        <translation>Baleraráse'l to discu al formatiar</translation>
     </message>
     <message>
         <location filename="../view/mainwindow.cpp" line="201"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Falló el formato del dispositivu</translation>
     </message>
     <message>
         <location filename="../view/mainwindow.cpp" line="202"/>
@@ -95,17 +94,17 @@
     <message>
         <location filename="../utils/udisksutils.cpp" line="55"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Discu del sistema</translation>
     </message>
     <message>
         <location filename="../utils/udisksutils.cpp" line="59"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Encriptáu'</translation>
     </message>
     <message>
         <location filename="../utils/udisksutils.cpp" line="61"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Volumen'</translation>
     </message>
 </context>
 <context>
@@ -113,16 +112,16 @@
     <message>
         <location filename="../main.cpp" line="112"/>
         <source>Device does not exist</source>
-        <translation>Nun esiste&apos;l preséu</translation>
+        <translation>Nun esiste'l preséu</translation>
     </message>
     <message>
         <location filename="../main.cpp" line="121"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
+        <translation>El dispositivu ta de solu lectura</translation>
     </message>
     <message>
         <source>Cannot format local device</source>
-        <translation type="vanished">Nun pue formatiase&apos;l preséu llocal</translation>
+        <translation type="vanished">Nun pue formatiase'l preséu llocal</translation>
     </message>
 </context>
 <context>
@@ -130,7 +129,7 @@
     <message>
         <location filename="../view/warnpage.cpp" line="43"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>El formato eliminará todos los datos nes esti discu, ¿estas seguru de qu'quieres continuar? No pue ser restablecíu.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_az.ts
+++ b/translations/dde-device-formatter_az.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Format uğurlu</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Disk formatlanır, lütfen bekleyin...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Növ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Etiket</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Hızlı Format</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Formatlama diskdəki bütün məlumatları siləcək.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Formatla</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Davam et</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Formatlanır...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Tamamlandı</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Çıx</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Diskiniz çıxarıldı</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Cihaz formatlanmadi</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Yeniden formatla</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>Tamdır</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Sistem Diski</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Şifrələnmiş'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Hacmi'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde cihaz formatlayıcı</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Cihaz mövcud deyil</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Cihaz oxunmaq üçün yalnız</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Formatlama bu diskdəki bütün məlumatları siləcək, davam etmək istəyirsinizmi? Onlar geri qaytarılmayacaq.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_bg.ts
+++ b/translations/dde-device-formatter_bg.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="bg" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bg">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Форматирането е успешно !</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Дискът се форматира. Моля, изчакайте...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Етикет</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Бързо форматиране</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Форматирането ще заличи всичките ви данни на диска.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Форматиране</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Продължаване</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Форматиране...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Изход</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>Насъщно е изваден диска</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Вашият диск е премахнат, когато се форматира</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Устройството не може да бъде форматирано</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Форматиране отново</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Системен диск</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Криптиран</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Устройство</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde устройство за форматиране</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Устройството не съществува</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Устройството е само за четене</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Локалното устройство не може да бъде форматирано</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Форматирането ще заличи всички данни на вашият диск. Сигурен ли сте, че искате да продължите? Те няма да могат да бъдат възстановени.</translation>
     </message>

--- a/translations/dde-device-formatter_bn.ts
+++ b/translations/dde-device-formatter_bn.ts
@@ -1,83 +1,84 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="bn" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>ফরম্যাট সফল</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>ডিস্ক ফরম্যাট করা হচ্ছে, অপেক্ষা করুন...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>ধরণ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>লেভেল</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>ট্রান্সফর্ম ফরম্যাট</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>ফরম্যাট করা ডিস্কে সমস্ত ডেটা মুছে দেবে।</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>ফরম্যাট</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>চালিয়ে যান </translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>ফরম্যাট করা হচ্ছে...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>সম্পূর্ণ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>বের হয়ে যান</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>ফরম্যাট করার সময় আপনার ডিস্কটি সড়িয়ে ফেলা হয়েসে</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>আপনার ডিস্ক অপসারণ করা হয়েছে</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>ডিভাইসটি ফরম্যাট করা হয়নি</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>পুনরায় ফরমেট করুন</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>ঠিক আছে</translation>
     </message>
@@ -93,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>সিস্টেম ডিস্ক</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 চিপ্স করা হয়েছে'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 ভলিউম'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>ডিডি ডিভাইস ফরম্যাটার</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>ডিভাইস বিদ্যামান নেই</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">লোকাল ডিভাইস ফরমেট করা যাচ্ছে না</translation>
+        <translation>ডিভাইসটি পঠন করা যায় কিন্তু লেখন করা যায় না</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>এই ডিস্কে সমস্ত ডেটা মুছে দেবে ফরম্যাট করা, আপনি আরো চালিয়ে যাবেন কি? এটি ফিরিয়ে নেওয়া যাবে না।</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_bo.ts
+++ b/translations/dde-device-formatter_bo.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_bqi.ts
+++ b/translations/dde-device-formatter_bqi.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bqi">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>التنسيق نجح</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>يتم تنسيق القرص، يرجى الانتظار...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>تنسيق سريع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>سيحذف التنسيق جميع البيانات الموجودة على القرص.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>التنسيق</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>المتابعة</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>يتم التنسيق...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>انتهى</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>الخروج</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>تم إزالة قرصك</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>فشل التنسيق الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>إعادة التنسيق</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>موافق</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>القرص النظامي</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 مشفر'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 الحجم'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde جهاز التنسيق</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>الجهاز غير موجود</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>الجهاز فقط القراءة</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>سيحذف التنسيق جميع البيانات الموجودة على هذا القرص، هل أنت متأكد من أنك تريد المتابعة؟ لا يمكن استعادة البيانات.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_br.ts
+++ b/translations/dde-device-formatter_br.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="br">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>التنسيق ناجح</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>جاري التنسيق على القرص، من فضلك انتظر...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>تنسيق سريع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>سيحذف التنسيق جميع البيانات الموجودة على القرص.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>التنسيق</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>الاستمرارية</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>جاري التنسيق...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>تم</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>الخروج</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>تم إزالة قرصك</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>فشل التنسيق الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>إعادة التنسيق</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>نعم</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>القرص النظامي</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 مشفر</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 حجم</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde أداة تنسيق الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>الجهاز غير موجود</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>الجهاز قابل للقراءة فقط</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>سيحذف التنسيق جميع البيانات الموجودة على هذا القرص، هل أنت متأكد من أنك تريد الاستمرار؟ ولا يمكن استعادة البيانات.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_ca.ts
+++ b/translations/dde-device-formatter_ca.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ca" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formatació correcta</translation>
     </message>
@@ -10,30 +12,30 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation>S&apos;està formatant el disc. Espereu...</translation>
+        <translation>S'està formatant el disc. Espereu...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Formatació ràpida</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>La formatació suprimirà totes les dades del disc.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formata</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Continua</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
-        <translation>S&apos;està formatant...</translation>
+        <translation>S'està formatant...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Fet</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Surt</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>El disc ha estat extret</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">El disc s&apos;extreu quan es formata.</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Ha fallat la formatació del dispositiu.</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Torna a formatar</translation>
     </message>
@@ -89,25 +86,25 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
-        <translation>D&apos;acord</translation>
+        <translation>D'acord</translation>
     </message>
 </context>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Disc de sistema</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>Xifrat: %1</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>Volum: %1</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>El dispositiu no existeix.</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>El dispositiu és només de lectura.</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">No es pot formatar el dispositiu local.</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>La formatació suprimirà totes les dades del disc. Segur que voleu continuar? No es podran restaurar.</translation>
     </message>

--- a/translations/dde-device-formatter_cs.ts
+++ b/translations/dde-device-formatter_cs.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="cs" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Úspěšně zformátováno</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formátuje se. Počkejte, prosím,...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Štítek</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Rychlé zformátování</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Formátování vymaže všechna data na disku.</translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formátovat</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Pokračovat</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formátuje se...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Ukončit</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Váš disk je při formátování odstraněn</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Vaše disk byl odpojen</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Nepodařilo se zformátovat zařízení</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Přeformátovat</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Systémový disk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>%1 zašifrován</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>%1 objem</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde formátor zařízení</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Zařízení není</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Nelze formátovat místní zařízení</translation>
+        <translation>Zařízení je jen pro čtení</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Formátování vymaže všechna data na disku. Opravdu chcete pokračovat? Data nepůjdou obnovit.</translation>
     </message>

--- a/translations/dde-device-formatter_da.ts
+++ b/translations/dde-device-formatter_da.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="da" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="da">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formatering lykkedes</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formaterer disken, vent venligst ...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Hurtig formatering</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Formatering vil rydde al data på disken.</translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatér</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Fortsæt</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formaterer...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Færdig</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Afslut</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Din disk fjernes ved formatering</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Din disk er fjernet</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Kunne ikke formatere enheden</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Formatér igen</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Systemdisk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>%1 Krypteret</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>%1 Volumen</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde enhedsformaterer</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Enheden findes ikke</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Kan ikke formatere lokal enhed</translation>
+        <translation>Enheden er skrivebeskyttet</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Formatering vil rydde al data på disken, er du sikker på, at du vil fortsætte? Det kan ikke gendannes.</translation>
     </message>

--- a/translations/dde-device-formatter_de.ts
+++ b/translations/dde-device-formatter_de.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formatierung erfolgreich</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formatierung der Festplatte, bitte warten...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Art</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Schnellformatierung</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Durch das Formatieren werden alle Daten auf der Festplatte gelöscht.</translation>
     </message>
@@ -41,47 +43,43 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <location filename="../view/mainwindow.cpp" line="86"/>
         <source>Format</source>
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Fortsetzen</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatierung...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Verlassen</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Ihre Festplatte wird beim Formatieren entfernt</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Fehler beim Formatieren des Geräts</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>neu formatieren</translation>
     </message>
@@ -89,7 +87,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -97,17 +95,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Systemfestplatte</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Verschlüsselt</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Volumen</translation>
     </message>
@@ -115,24 +113,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Gerät existiert nicht</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Das Gerät ist schreibgeschützt</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Lokales Gerät kann nicht formatiert werden</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Durch das Formatieren werden alle Daten auf dieser Festplatte gelöscht. Möchten Sie wirklich fortfahren? Die Daten können nicht wiederhergestellt werden.</translation>
     </message>

--- a/translations/dde-device-formatter_el.ts
+++ b/translations/dde-device-formatter_el.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="el" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="el">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Επιτυχής μορφοποίηση</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Μορφοποίηση, παρακαλούμε περιμένετε...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Τύπος</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Ετικέττα</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Γρήγορη Μορφοποίηση</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Μορφοποιώντας, θα σβηστούν όλα τα δεδομένα στον δίσκο. </translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Μορφοποίηση</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Συνέχεια</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Μορφοποίηση...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Τέλος</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Ο δίσκος σας αφαιρέθηκε κατά τη μορφοποίηση</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Το δίσκος σας έχει αποσυρθεί</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Αποτυχία της φόρματτινγκ του συσκευαστικού</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Επαναμορφοποίηση</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Δίσκος Συστήματος</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Κρυπτογραφημένος'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Χώρος'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Δεν υπάρχει η συσκευή</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Δεν είναι δυνατή η μορφοποίηση της τοπικής συσκευής</translation>
+        <translation>Το συσκευαστικό είναι αναγνωστικό</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Η λειτουργία μορφοποίησης θα καθαρίσει όλα τα δεδομένα από το δίσκο σας, είστε βέβαιοι ότι θα συνεχίσετε; Αυτή η επιλογή δεν μπορεί να αποκατασταθεί.</translation>
     </message>

--- a/translations/dde-device-formatter_en_AU.ts
+++ b/translations/dde-device-formatter_en_AU.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_AU">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Format successful</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Formatting the disk, please wait...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Label</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Quick Format</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Formatting will erase all data on the disk.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Format</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Continue</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Formatting...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Done</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Quit</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Your disk has been removed</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Failed to format the device</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Reformat</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>System Disk</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Encrypted'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Volume'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Device does not exist</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>The device is read-only</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_eo.ts
+++ b/translations/dde-device-formatter_eo.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eo">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Formato sukcesis</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Formatado la disko, bonvolu atendi...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Etikedo</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Rapida Formato</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Formatado estos forĵetos ĉiuj datoj sur la disko.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Formato</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Daŭrigi</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Formatado...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Finita</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Forlasi</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Via disko estis forplukolit</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Malsukcesis formati la enhavon</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Reformati</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Sistemo Disko</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Ĉifrita'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Volumo'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde enhavformataj</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>La enhavo ne ekzistas</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>La enhavo estas nur-lega</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Formatado estos forĵetos ĉiuj datoj sur tiu disko, certe vi volas daŭrigi? Ĉi tio ne povas esti restaŭro.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_es.ts
+++ b/translations/dde-device-formatter_es.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="es" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formato exitoso</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formateando el disco, por favor espere ...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Formato rápido</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>El formateo borrará todos los datos del disco.</translation>
     </message>
@@ -41,43 +43,43 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <location filename="../view/mainwindow.cpp" line="86"/>
         <source>Format</source>
         <translation>Formatear</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formateando...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Quitar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>El disco se quitará al formatear</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>No se ha podido formatear el dispositivo</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Reformatear</translation>
     </message>
@@ -85,7 +87,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
@@ -93,42 +95,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>El dispositivo no existe</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">No se puede formatear el dispositivo local</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>El formateo borrará definitivamente, todos los datos de este disco, ¿está seguro de que desea continuar? </translation>
     </message>

--- a/translations/dde-device-formatter_et.ts
+++ b/translations/dde-device-formatter_et.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="et">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Vorming on õnnestunud</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Vorming hoida, palun oota...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Tüüp</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Märksõna</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Kiire vorming</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Vorming kustub kõik andmed kettal.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Vorming</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Jätka</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Vormingu...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Valmis</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Välju</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Sinu kett on eemaldatud</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Tähtsuse vorming ebaõnnestus</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Taasvorming</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Süsteemikett</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Krüptitud'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Tulu'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde seadmete vormija</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Seadet ei ole</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Seade on kaitstud</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Vorming kustub kõik andmed selle kettal, kas soovid jätkata? Seda ei saa taastada.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_eu.ts
+++ b/translations/dde-device-formatter_eu.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eu">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Formatu egoki</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Diska formatatzen ari da, etorri gabe...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Mota</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Etiketa</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Formatua Hasteko</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Formatatzeak diskan dagoen datu guztiak ezabatuko ditu.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Formatua</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Jarraitu</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Formatatzen...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Bite</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Irten</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Zure diskak kendu da</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Gertu ezin da formatatzeko gertu</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Berriformatua</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Sistema Diskoa</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Enkriptatua'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Bolumena'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde gertu formatatzailea</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Gertu ez da existitzen</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Gertu bakarrik irakurrita dago</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Formatatzeak gertu horretan dagoen datu guztiak ezabatuko ditu, seguru al da zuek jarraitu nahi duzula? Ezin da berrezarri.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_fa.ts
+++ b/translations/dde-device-formatter_fa.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fa">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>فرمت‌سازی موفقیت‌آمیز بود</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>فرمت‌سازی دیسک، لطفا منتظر بمانید...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>برچسب</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>فرمت سریع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>فرمت‌سازی تمام داده‌های دیسک را حذف خواهد کرد.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>فرمت</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>ادامه</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>فرمت‌سازی...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>完了</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>خروج</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>دیسک شما از بین رفته است</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>فرمت‌سازی دستگاه ناموفق بود</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>بازفرمت</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>تایید</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>دیسک سیستم</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 رمزگذاری شده'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 جلد'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde فرمت‌ساز دستگاه</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>دستگاه وجود ندارد</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>دستگاه فقط خواندنی است</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>فرمت‌سازی تمام داده‌های این دیسک را حذف خواهد کرد، مطمئن هستید که می‌خواهید ادامه دهید؟ این داده‌ها قابل بازیابی نیست.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_fi.ts
+++ b/translations/dde-device-formatter_fi.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="fi" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Alustus onnistui</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Levyn alustaminen, odota ...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tyyppi</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Nimilappu</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Nopea formatointi</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Alustaminen poistaa kaikki levyllä olevat tiedot.</translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Alusta</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Jatka</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Alustaa...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Tehty</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Lopeta</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Levy poistetaan alustettaessa</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>HDD:n poistettiin</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Laitteen alustaminen epäonnistui</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Pyyhitään</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>ok</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Järjestelmälevy</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>%1 salattu</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>%1 tilavuus</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde laitteen muokkuri</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Laitetta ei ole</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Paikallista laitetta ei voi alustaa</translation>
+        <translation>Laitteella on vain lukukäyttö</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Alustaminen poistaa kaikki tämän levyn tiedot, oletko varma, että haluat jatkaa? Sitä ei voi palauttaa.</translation>
     </message>

--- a/translations/dde-device-formatter_fil.ts
+++ b/translations/dde-device-formatter_fil.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fil">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Nagawa ang format</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Nag-format ng disk, mangunguna ka...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Etiketa</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Mabilis na Format</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Ang pag-format ay magpapalit ng lahat ng data sa disk.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Format</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Sugtan</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Nag-format...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Tapos na</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Iwan</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Nakakatapon ang iyong disk</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Nagkagawa ang pag-format ng aparato</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Ibalik ang format</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Sistemang Disk</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Naka-encrypt'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Volume'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Ang aparato ay di-maari</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Ang aparato ay lamang na nakaread</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Ang pag-format ay magpapalit ng lahat ng data sa disk na ito, siguro ka nais magpatuloy? Hindi ito maaaring iibalik.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_fr.ts
+++ b/translations/dde-device-formatter_fr.ts
@@ -1,95 +1,92 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="fr" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>التنسيق ناجح</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>يتم التنسيق القرص، من فضلك انتظر...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Libellé</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>تنسيق سريع</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>سيؤدي التنسيق إلى حذف جميع البيانات على القرص.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Continuer</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
-        <translation type="unfinished"/>
+        <translation>يتم التنسيق...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Terminé</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>تم إزالة قرصك</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>فشل التنسيق الجهاز</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
-        <translation type="unfinished"/>
+        <translation>إعادة التنسيق</translation>
     </message>
 </context>
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -97,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>القرص النظامي</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 مشفر'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 الحجم'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
-        <translation>L&apos;appareil n&apos;existe pas</translation>
+        <translation>L'appareil n'existe pas</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="unfinished"/>
+        <translation>الجهاز فقط القراءة</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>سيؤدي التنسيق إلى حذف جميع البيانات على هذا القرص، هل أنت متأكد من الرغبة في الاستمرار؟ لا يمكن استعادة البيانات.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_gl_ES.ts
+++ b/translations/dde-device-formatter_gl_ES.ts
@@ -1,83 +1,84 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="gl_ES" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>Formato exitoso</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Formatando o disco, por favor espere...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>Formato rápido</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>O formato eliminará todos os datos do disco.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatando...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Feito</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Saír</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Disco expulsado durante o formatado</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>O seu disco foi desmontado</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Produciuse un erro ao formatar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Volver formatar</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
@@ -93,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Disco do sistema</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Encriptado'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Volume'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>O dispositivo non existe</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Non se pode formatar o dispositivo local</translation>
+        <translation>O dispositivo está en modo de lectura solo</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>O formato eliminará todos os datos deste disco, ¿está seguro de que quere continuar? Non pode ser restaurado.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_he.ts
+++ b/translations/dde-device-formatter_he.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>ה포ורמט הושלם</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>מפורמט את הדיסק, אנא המתן...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>סוג</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>שם</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>포르מט מהיר</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>ה포ורמט ימחק את כל המידע על הדיסק.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>פורמט</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation> המשך</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>מפורמט...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>הושלם</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>יציאה</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>הדיסק שהוסר</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>ה포ורמט נכשל עבור התקן</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>פורמט מחדש</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>בסדר</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>דיסק חיצוני</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 מוצפן'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 נפח'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>התקן לא קיים</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>התקן הוא קרוא רק</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>ה포ורמט ימחק את כל המידע על הדיסק, האם אתה בטוח שברצונך להמשיך? הוא לא יכול להיות לשחזר.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_hi_IN.ts
+++ b/translations/dde-device-formatter_hi_IN.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>फॉरमेट सफल</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>डिस्क के फॉरमेट कर रहे हैं, कृपया इंतजार करें...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>ईटिकेट</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>त्वरित फॉरमेट</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>फॉरमेट करने से डिस्क पर सभी डेटा मिट जाएगा।</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>फॉरमेट</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>जारी रखें</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>फॉरमेट कर रहे हैं...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>काम कर लिया</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>छोड़ें</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>आपकी डिस्क हटा ली गई है</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>उपकरण के फॉरमेट करने में विफल</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>फिर से फॉरमेट करें</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>ठीक है</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>सिस्टम डिस्क</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 एन्क्रिप्ट किया गया'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 वॉल्यूम'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde उपकरण फॉरमेटर</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>उपकरण नहीं मौजूद है</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>उपकरण केवल पढ़ने के लिए है</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>इस डिस्क पर सभी डेटा मिट जाएगा, क्या आप जारी रखना चाहते हैं? इसे बहाल नहीं किया जा सकता।</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_hr.ts
+++ b/translations/dde-device-formatter_hr.ts
@@ -1,83 +1,84 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="hr" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>Formatiranje je uspješno</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Formatiranje diska, molim čekajte...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Natpis</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>Brzi format</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>Formatiranje će izbrisati sve podatke s diska.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatiraj</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Nastavi</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatiram...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Učinjeno</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Završi</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Nakon formatiranja vaš disk je uklonjen</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Vaš disk je uklonjen</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Formatiranje uređaja nije uspješno</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Ponovno formatiraj</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>U redu</translation>
     </message>
@@ -93,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Sustavni disk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>%1 šifrirano</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>%1 volumen</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde uređaj za formatiranje</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Uređaj ne postoji</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Ne mogu formatirati lokalni uređaj</translation>
+        <translation>Uređaj je samo za čitanje</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>Formatiranje će izbrisati sve podatke na ovom disku, sigurno želite nastaviti? Ne može se obnoviti.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_hu.ts
+++ b/translations/dde-device-formatter_hu.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="hu" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formázás sikeres</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Lemez formázása, kérem várjon...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Címke</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Gyorsformázás</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>A formázás törölni fogja az összes adatait a lemezen.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formázás</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Folytatás</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formázás...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Kész</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Kilépés</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>A merevlemez eltávolításra került</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Formázás közben a lemezt leválasztjuk</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Nem sikerült leformázni az eszközt.</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Újraformázás</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Rendszerlemez</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Titkosítva</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Terjedelem</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde eszköz formázó</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Az eszköz nem található</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Az eszköz csak olvasható</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Nem lehet formázni a helyi eszközt</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>A formázás le fogja törölni az összes adatát a lemezen. Biztos hogy folytatni akarja? A folyamat nem visszafordítható.</translation>
     </message>

--- a/translations/dde-device-formatter_hy.ts
+++ b/translations/dde-device-formatter_hy.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hy">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Ձևափոխումը հաջողված է</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Ներածող սկավառակը, խնդրում է կարգավորել...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Տիպ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Նիշ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Արագ ձևափոխում</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Ձևափոխումը կջատի սկավառակի բոլոր տվյալները</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Ձևափոխել</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Շարունակել</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Ձևափոխում...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Ավարտված է</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Եզրափակել</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Ձեր սկավառակը հեռացրել է</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Սարքը ձևափոխելու համար անհնար է եղել</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Վերաձևափոխել</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>Այո</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Համակարգի սկավառակ</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 գաղափարական'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 ծավալ'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde սարքի ձևափոխում</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Սարքը գոյություն չունի</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Սարքը միայն կարդալիք է</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Ձևափոխումը կջատի սկավառակի բոլոր տվյալները, ցանկանում եք շարունակել արդյունավետ ձևափոխումը? Այն հնարավոր չէ վերականգնել</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_id.ts
+++ b/translations/dde-device-formatter_id.ts
@@ -1,83 +1,84 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="id" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>Format berhasil</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Memformat disk, mohon menunggu...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>Format Cepat</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>Memformat akan menghapus semua data di disk.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Lanjutkan</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Memformat...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Selesai</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Berhenti</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Diska Anda dihapus ketika memformat</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Disk Anda telah diangkat</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Gagal memformat perangkat</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Format ulang</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Disk Sistem</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Terenkripsi'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Volume'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Perangkat tidak ada</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Tidak dapat memformat diska lokal</translation>
+        <translation>Perangkat ini hanya untuk dibaca</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>Memformat akan menghapus semua data di disk ini, apakah Anda yakin ingin melanjutkan? Tidak dapat dipulihkan.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_it.ts
+++ b/translations/dde-device-formatter_it.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="it" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formattazione conclusa</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formattazione in corso, attendere prego..</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tipologia</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etichetta</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Formattazione rapida</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>La formattazione eliminerà tutti i dati dal disco</translation>
     </message>
@@ -41,47 +43,43 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <location filename="../view/mainwindow.cpp" line="86"/>
         <source>Format</source>
         <translation>Formatta</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Continua</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formattazione...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Termina</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Il disco sarà rimosso dopo la formattazione</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Formattazione disco fallita</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Riformatta</translation>
     </message>
@@ -89,7 +87,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -97,17 +95,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Disco di Sistema</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Crittografato</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>Volume %1</translation>
     </message>
@@ -115,24 +113,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Il dispositivo non esiste</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Il dispositivo è in sola lettura</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Impossibile formattare il dispositivo locale</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Formattando eliminerai tutti i dati dal disco, sicuro di voler continuare? I dati presenti saranno persi definitivamente.</translation>
     </message>

--- a/translations/dde-device-formatter_ja.ts
+++ b/translations/dde-device-formatter_ja.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ja" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>フォーマット成功</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>ディスクをフォーマット中、しばらくお待ちください...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>種類</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>クイックフォーマット</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>フォーマットはディスク内のすべてのデータを削除します。</translation>
     </message>
@@ -41,43 +43,43 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <location filename="../view/mainwindow.cpp" line="86"/>
         <source>Format</source>
         <translation>フォーマット</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>続ける</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>フォーマット中...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>フォーマット中にディスクが取り出されました</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>再フォーマット</translation>
     </message>
@@ -85,7 +87,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,42 +95,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>デバイスが存在しません</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">ローカルデバイスをフォーマットできません</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>フォーマットはディスク内のすべてのデータを削除しますが続行しますか？復元はできません。</translation>
     </message>

--- a/translations/dde-device-formatter_ka.ts
+++ b/translations/dde-device-formatter_ka.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ka">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>ფორმატირება წარმატებულია</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>დისკზე ფორმატირება, გთხოვთ დაელოდოთ...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>ტიპი</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>სათანადობი</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>სწრაფი ფორმფიტირება</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>ფორმატირება დაამალებს დისკზე ყველა მონაცემს.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>ფორმატირება</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>გაგრძელება</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>ფორმატირება...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>დასრულებულია</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>გასვლა</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>თქვენი დისკი გამოყოფილია</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>მოწყობილობას არ არის შესაძლებელი ფორმატირება</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>განახლების ფორმატირება</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>კარგი</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>ისტემის დისკი</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 დაშიფრულია'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 საშიფრო მოწყობილობა'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde მოწყობილობის ფორმატირების პროგრამა</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>მოწყობილობა არ არსებობს</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>მოწყობილობა მხოლოდ წაკითხვის საშიშია</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>ფორმატირება დაამალებს ამ დისკზე ყველა მონაცემს, თუ გსურთ გაგრძელება? ის არ არის დაბრუნებული.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_km_KH.ts
+++ b/translations/dde-device-formatter_km_KH.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="km_KH">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>ការបញ្ចែញទម្រង់បានជោគជំនគ</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>កំពុងបញ្ចែញទម្រង់ដៃគឺ សូមរង់ចាំ...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>សំឡេង</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>បញ្ចែញទម្រង់ប្រហែល</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>ការបញ្ចែញទម្រង់នឹងលុបទិន្នន័យទាំងអស់នៅលើដៃគឺ។</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>បញ្ចែញទម្រង់</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>បន្ត</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>កំពុងបញ្ចែញទម្រង់...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>បំពេញ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>ចាប់ផ្តើម</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>ដៃគឺរបស់អ្នកត្រូវបានដកចេញ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>ការបញ្ចែញទម្រង់ដៃគឺបានបរាជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>បញ្ចែញទម្រង់ឡើងវិញ</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>សម្រេច</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>ដៃគឺប្រព័ន្ធដែលបានបញ្ចែញទម្រង់</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 បានបញ្ចែញទម្រង់'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 ប្រភេទ'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>កម្មវិធីបញ្ចែញទម្រង់ដៃគឺ DDE</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>មិនមានឧបករណ៍ណាមួយនៅទីនោះ</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>ឧបករណ៍នេះមានសមត្ថភាពអាចអានបានតែមិនអាចកែប្រែបាន</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>ការបញ្ចែញទម្រង់នឹងលុបទិន្នន័យទាំងអស់នៅលើដៃគឺនេះ តើអ្នកចង់បន្តទេ? វាមិនអាចនឹងត្រលប់មកវិញបានទេ។</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_kn_IN.ts
+++ b/translations/dde-device-formatter_kn_IN.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="kn_IN">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>ಆಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ ಯಶಸ್ವಿಯಾಗಿದೆ</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>ಡಿಸ್ಕ್ ಆಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ, ಕೊನೆಗೊಳಿಸಲು ಕಾಯಿರಿ</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>ತರಹ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>ನಿಶ್ಚಯಿಸಿ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>ಶೀಘ್ರ ಆಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>ಆಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ ಡಿಸ್ಕ್‌ನಲ್ಲಿರುವ ಎಲ್ಲಾ ಡೇಟಾವನ್ನು ತೆಗೆದುಹಾಕುತ್ತದೆ.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>ಆಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>ನಿಯತಿ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>ಆಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>ಗುರಿಯನ್ನು ತಲುಪಿದೆ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>ಬಿಡು</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>ನೀವು ಡಿಸ್ಕ್ ನ್ನು ತೆಗೆದುಹಾಕಿದ್ದೀರಿ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>ಆಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ ಯಶಸ್ವಿಯಾಗಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>ಪುನರಾಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>ಆಯ್ಕೆ ಮಾಡಿ</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>ಸಿಸ್ಟಮ್ ಡಿಸ್ಕ್</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 ಗುಪ್ತಗೊಂಡಿದೆ'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 ಸ್ಥಳ'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>ಡೇ ಡಿಸ್ಕ್ ಸುಪ್ರತಿಷ್ಠಾಪನೆ ಮಾಡುವ ಸಾಧನ</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>ಸಾಧನ ಇದು ಅಸ್ತಿತ್ವದಲ್ಲಿಲ್ಲ</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>ಸಾಧನ ಕೇವಲ ಪಠ್ಯವನ್ನು ಓದಲು ಅನುಮತಿಸುತ್ತದೆ</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>ಆಕಾರ ಸುಪ್ರತಿಷ್ಠಾಪನೆ ಈ ಡಿಸ್ಕ್‌ನಲ್ಲಿರುವ ಎಲ್ಲಾ ಡೇಟಾವನ್ನು ತೆಗೆದುಹಾಕುತ್ತದೆ, ನೀವು ನಿಯತಿ ಮಾಡಲು ನಿಶ್ಚಯಿಸಿದ್ದೀರಾ? ಅದನ್ನು ಮರುನಿರ್ಮಾಣ ಮಾಡಲಾಗದೆ.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_ko.ts
+++ b/translations/dde-device-formatter_ko.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ko" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>포맷 성공</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>디스크를 포맷하는 중, 잠시 기다리십시오...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>종류</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>레이블</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>빠른 포멧</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>포맷하면 디스크의 모든 데이터가 지워집니다.</translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>포맷</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>계속</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>포맷중...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>포맷중에 디스크가 제거되었습니다</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>당신의 디스크가 제거되었습니다</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>장치를 포맷하지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>재포맷</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>확인</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>시스템 디스크</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 암호화됨'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 볼륨'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde 장치 포맷터</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>장치가 존재하지 않습니다</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">로컬 장치는 포맷할 수 없습니다</translation>
+        <translation>이 장치는 읽기 전용입니다</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>포맷하면 이 디스크의 모든 데이터가 지워집니다. 계속하시겠습니까? 복원할 수 없습니다.</translation>
     </message>

--- a/translations/dde-device-formatter_ku.ts
+++ b/translations/dde-device-formatter_ku.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ku">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>فرمتی باری</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>فرمت کردن دیسک، لطفا بچکونە بکەرەوە...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>ئەتەت</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>فرمت کردنی سریع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>فرمت کردن داده‌کانی دیسک را دەکاتەوە.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>فرمت کردن</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>بچکونە بکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>فرمت کردن...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>تەمەم</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>پەرەستەر</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>دیسکی تو چکونە بکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>فرمت کردنی دەستگەر بەگەڕاوە</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>بە دووبارە فرمت کردن</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>تۆمار کردن</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>دیسکی سیستەم</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 چەک کردن'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 دەرەک'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde فرمت کارەر</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>دەستگەر نەدۆزرە</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>دەستگەر ڕەد ئۆنە</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>فرمت کردن داده‌کانی دیسکی ئەمە بەکاتەوە، ئەمە بەکاتەوە بەکەرەوە؟ لە نەتەوە بەکاتەوە نەدەوە.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_ku_IQ.ts
+++ b/translations/dde-device-formatter_ku_IQ.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ku_IQ">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>فرمەتکردن باشکەسیلیت</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>فرمەتکردنەوە دویشکە، لە چەکەوە...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>ئەتەت</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>فرمەتکردنی سریع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>فرمەتکردنەوە دویشکە داتاکە ئەوە دویشکە بەکەسیلیت</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>فرمەتکردن</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>بەکەردن</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>فرمەتکردنەوە...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>تواند</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>پەرەچەوە</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>دویشکە شما بەکەرەوە</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>فرمەتکردنەوە دویشکە باشکەسیلیت</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>بەرەوە فرمەتکردن</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>دیسکی سیستم</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 بەکەسیلیت</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 ئەتەت</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde فرمەتکردنەوە دویشکە</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>دویشکە دەکەسیلیت</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>دویشکە بەکەسیلیت</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>فرمەتکردنەوە دویشکە داتاکە ئەوە دویشکە بەکەسیلیت، هەڵەوە هەر کەرەوە بەکەردن؟ ئەو دەکەسیلیت بەکەردنەوە</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_ky.ts
+++ b/translations/dde-device-formatter_ky.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ky">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Форматталды</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Диск форматталып, күтүү...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Түр</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Этикетка</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Тез формат</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Форматталу дисктагы барлык маълуматты өчүрөт.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Формат</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Далында</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Форматталу...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Түзүү</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Чығу</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Сиздин дискыңыз алынды</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Аспа форматталган</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Форматтануу</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>Баар</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Системдик диск</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 шифрланган'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 тому'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde ылдый форматтауы</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Аспа ылдый</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Аспа ылдый өзгөрө алмай</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Форматталу бул томдагы барлык маълуматты өчүрөт, сиз өзгөрө алмай, үзгөртүү үчүн сизге ыңгайлы үзгөрө алмай?</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_lt.ts
+++ b/translations/dde-device-formatter_lt.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="lt" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formatavimas sėkmingas</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Diskas formatuojamas, palaukite...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tipas</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etiketė</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Spartusis formatavimas</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Formatavimas ištrins visus diske esančius duomenis.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatuoti</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Tęsti</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatuojama...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Atlikta</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Išeiti</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>Jūsų diskas buvo pašalintas</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Formatuojant, jūsų diskas yra pašalinamas</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Nepavyko formatuoti įrenginio</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Formatuoti iš naujo</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>Gerai</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Sistemos diskas</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>Šifruotas %1</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 tomas</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde įrenginio formateris</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Įrenginio nėra</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Šis įrenginys yra skirtas tik skaitymui</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Negalima formatuoti vietinį įrenginį</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Formatavimas ištrins visus šiame diske esančius duomenis, ar tikrai norite tęsti? Duomenų bus nebeįmanoma atkurti.</translation>
     </message>

--- a/translations/dde-device-formatter_ml.ts
+++ b/translations/dde-device-formatter_ml.ts
@@ -1,136 +1,138 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ml" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ml">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>ഫോർമാറ്റ് വിജയിച്ചു</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>ഡിസ്ക് ഫോർമാറ്റ് ചെയ്യുക, പ്രതീക്ഷിക്കുക...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>തരം</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
-        <translation type="unfinished"/>
+        <translation>ലേബൽ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>ഫാസ്റ്റ് ഫോർമാറ്റ്</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>ഫോർമാറ്റിംഗ് ഡിസ്കിലെ എല്ലാ ഡാറ്റയും മായ്ക്കും.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
-        <translation type="unfinished"/>
+        <translation>ഫോർമാറ്റ്</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
-        <translation type="unfinished"/>
+        <translation>പുനരാരംഭം</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
-        <translation type="unfinished"/>
+        <translation>ഫോർമാറ്റിംഗ്...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation>വിജയിച്ചു</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
-        <translation type="unfinished"/>
+        <translation>നിർത്തു</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation type="unfinished"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>നിങ്ങളുടെ ഡിസ്ക് നീക്കം ചെയ്തിരിക്കുന്നു</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>ഡിവൈസ് ഫോർമാറ്റ് ചെയ്യാൻ കഴിയില്ല</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
-        <translation type="unfinished"/>
+        <translation>പുനർഫോർമാറ്റ്</translation>
     </message>
 </context>
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation>ഓക്കെ</translation>
     </message>
 </context>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>സിസ്റ്റം ഡിസ്ക്</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നു'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 വോളൂം'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde ഡിവൈസ് ഫോർമാറ്റർ</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
-        <translation type="unfinished"/>
+        <translation>ഡിവൈസ് ഇല്ല</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="unfinished"/>
+        <translation>ഡിവൈസ് പഠിക്കാൻ പുറത്ത് കഴിയില്ല</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>ഫോർമാറ്റിംഗ് ഈ ഡിസ്കിലെ എല്ലാ ഡാറ്റയും മായ്ക്കും. നിങ്ങൾ പുനരാരംഭം ചെയ്യാൻ തയാറാണോ? ഇത് പുനരധിവേശം ചെയ്യാൻ കഴിയില്ല.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_mn.ts
+++ b/translations/dde-device-formatter_mn.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="mn">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Форматыг амжилттай гүйцэтгэсэн</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Диск форматлах, байхад байна...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Төрөл</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Нэр</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Хурдан форматлах</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Форматлах үед диск дээрх бүх үүлбэр устах болно.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Форматлах</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Үргэлжлүүлэх</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Форматлах...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Гүйцэтгэсэн</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Хаах</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Диск устгагдсан</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Хэрэглэгчийн үүлбэр форматлахад амжилтгүй байна</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Дахин форматлах</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>Хороо</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Систем диск</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Үүлбэртэй'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 томоо'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde үүлбэр форматлах програм</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Хэрэглэгч нь байхгүй</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Хэрэглэгч нь уншихад зориулагдсан</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Форматлах үед энэ диск дээрх бүх үүлбэр устах болно, үргэлжлүүлэхэд та итгэх юу? Үүнийг буцаах боломжгүй.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_mr.ts
+++ b/translations/dde-device-formatter_mr.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="mr">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>फॉरमैट सार्वजनिक झाला</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>डिस्क फॉरमैट करत आहे, कृपया वेट करा...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>प्रकार</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>लेबल</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>फॉरमैट करा</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>फॉरमैट करण्याने डिस्क वरील सर्व डेटा नष्ट होईल.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>फॉरमैट</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>त्याच रीतीने चालू ठेवा</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>फॉरमैट करत आहे...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>पूर्ण</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation> बंद करा</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>तुमचा डिस्क विहित करण्यात आला आहे</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>उपकरण फॉरमैट करता अयशस्वी झाले</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>पुन्हा फॉरमैट करा</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>ओके</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>सिस्टम डिस्क</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 चीप करण्यात आली'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 वॉल्यूम'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde डिव्हाइस फॉर्मेटर</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>उपकरण अस्तित्व नाही</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>उपकरण अलीकडे वाचण्यासाठी वाचण्यासाठी वाचत नाही</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>हा डिस्क वरील सर्व डेटा नष्ट होईल, तुम्ही आणखी चालू ठेवायचे आहे का? तो पुन्हा निर्माण केला जाऊ शकत नाही.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_ms.ts
+++ b/translations/dde-device-formatter_ms.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ms" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Format berjaya</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Memformat cakera, tunggu sebentar...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Format Pantas</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Pemformatan akan mengosongkan semua data yang ada di dalam cakera.</translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Teruskan</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Memformat....</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Selesai</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Keluar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Cakera anda telah ditanggalkan ketika memformat</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Disk anda telah dikeluarkan</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Gagal memformat peranti</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Format Semula</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Disk Sistem</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Terkunci'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Blok'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Peranti tidak wujud</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Tidak dapat format peranti setempat</translation>
+        <translation>Peranti ini adalah baca sahaja</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Pemformatan akan mengosongkan semua data yang ada di dalam cakera ini, anda pasti mahu teruskan? Tindakan ini tidak boleh dipulihkan.</translation>
     </message>

--- a/translations/dde-device-formatter_my.ts
+++ b/translations/dde-device-formatter_my.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="my">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>การจัดรูปแบบสำเร็จ</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>กำลังจัดรูปแบบดิสก์ กรุณารอสักครู่...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>การจัดรูปแบบเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>การจัดรูปแบบจะลบข้อมูลทั้งหมดในดิสก์</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>จัดรูปแบบ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>ดำเนินการต่อ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>กำลังจัดรูปแบบ...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>เสร็จสิ้น</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>ออก</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>ดิสก์ของคุณถูกถอดออกแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>ไม่สามารถจัดรูปแบบอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>จัดรูปแบบใหม่</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>ตกลง</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>ดิสก์ระบบ</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 ถูกเข้ารหัส'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 ปริมาณ'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>อุปกรณ์ไม่มีอยู่</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>อุปกรณ์เป็นแบบอ่าน-only</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>การจัดรูปแบบจะลบข้อมูลทั้งหมดในดิสก์นี้ คุณแน่ใจว่าต้องการดำเนินการต่อหรือไม่? ข้อมูลจะไม่สามารถกู้คืนได้</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_nb.ts
+++ b/translations/dde-device-formatter_nb.ts
@@ -1,83 +1,84 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="nb" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nb">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>Formateringen har vellykket</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Formatterer disken, vennligst vent...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>Rapid Format</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>Formatering vil slette alle data på disken.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatter</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Fortsett</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formaterer...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Ferdig</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Avslutt</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Enheten ble fjernet mens formateringen pågikk</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Din disk har blitt fjernet</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Formateringen feilet</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Omformater</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Systemdisk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Kryptert'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Volum'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde-enhet formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Enheten eksisterer ikke</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Kan ikke formatere lokal enhet</translation>
+        <translation>Enhetskontoen er slettet</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>Formatering vil slette alle data på denne disken, er du sikker på at du vil fortsette? Det kan ikke gjenopprettes.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_ne.ts
+++ b/translations/dde-device-formatter_ne.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ne" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>फर्म्याट सफलभयो </translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>डिस्क फर्म्याट गर्दै, कृपया प्रतीक्षा गर्नुहोस् ...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>प्रकार</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>लेबल</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>द्रुत गतिमा  फर्म्याट </translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>फर्म्याटिले डिस्कमा भाएको सबै डाटा मेटिनेछ।</translation>
     </message>
@@ -41,48 +43,43 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>फर्म्याट </translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>जारी राख्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>फर्म्याट गर्दै</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>भयो</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>छोड्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>तपाईँको डिस्क हटाइएको छ</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">फर्म्याट गर्दा तपाईंको डिस्क हटाइन्छ</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>उपकरण फर्म्याट गर्न असफल भयो
  </translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>पुन: फर्म्याट </translation>
     </message>
@@ -90,7 +87,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>ठिक छ</translation>
     </message>
@@ -98,17 +95,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>प्रणाली डिस्क</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>% 1 ईन्क्रिप्टेड</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>% 1 खण्ड</translation>
     </message>
@@ -116,24 +113,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde डिवाइस फॉर्मेटर</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>उपकरण अवस्थित छैन</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>उपकरण पढ्ने मात्र हो</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">स्थानीय उपकरण फर्म्याट गर्न सकिदैन</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>फर्म्याटिले यस डिस्कमा सबै डाटा मेटिनेछ, के तपाइँ पक्का हुनुहुन्छ तपाइँ जारी राख्न चाहानुहुन्छ? यो पूर्वावस्थामा ल्याउन सकिदैन।</translation>
     </message>

--- a/translations/dde-device-formatter_nl.ts
+++ b/translations/dde-device-formatter_nl.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="nl" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formatteren voltooid</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Bezig met formatteren; even geduld...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Soort</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Snel formatteren</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Door het formatteren worden alle gegevens op de schijf gewist.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatteren</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Doorgaan</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Bezig met formatteren...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>Uw schijf is verwijderd</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Je schijf is ontkoppeld tijdens het formatteren</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Kan schijf niet formatteren</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Opnieuw formatteren</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>Oké</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Systeemschijf</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 versleuteld</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1-schijf</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde apparaat formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Schijf bestaat niet</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>De schijf is alleen-lezen</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Kan lokale schijf niet formatteren</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Door het formatteren worden alle gegevens op de schijf gewist. Weet je zeker dat je wilt doorgaan? Het proces kan niet ongedaan worden gemaakt.</translation>
     </message>

--- a/translations/dde-device-formatter_pa.ts
+++ b/translations/dde-device-formatter_pa.ts
@@ -1,83 +1,84 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pa" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pa">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>فرمت کرݨ ݙیکھی</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>ڈسک فرمت کرݨ ݙیکھی، چھوڑݨ ݙیکھی</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>ਕਿਸਮ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>ਲੇਬਲ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>فاسٹ فرمت</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>فرمت کرݨ ڈسک دی ساری ݢیݢی ݢیݢی چھوڑݨ ݙیکھی</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>ਫਾਰਮੈਟ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>ਜਾਰੀ ਰੱਖੋ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>...ਫਾਰਮੈਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>ਮੁਕੰਮਲ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>ਬਾਹਰ</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>ਫਾਰਮੈਟ ਕਰਨ ਦੇ ਦੌਰਾਨ ਤੁਹਾਡੀ ਡਿਸਕ ਨੂੰ ਹਟਾਇਆ ਜਾਂਦਾ ਹੈ</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>آپ دا ڈسک ہٹا ݢیݢی</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>ڈیوائس فرمت کرݨ ݢیݢی ݢیݢی</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>ਮੁੜ-ਫਾਰਮੈਟ ਕਰੋ</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>ਠੀਕ ਹੈ</translation>
     </message>
@@ -93,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>سسٹم ڈسک</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>%1 انجنکریٹ ݢیݢی</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>%1 وولیوم</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde ڈیوائس فرمت کرݨ دا ایپیکشن</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>ਡਿਵਾਈਸ ਮੌਜੂਦ ਨਹੀਂ ਹੈ</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">ਲੋਕਲ ਡਰਾਇਵ ਨੂੰ ਫਾਰਮੈਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ</translation>
+        <translation>ڈیوائس ریڈ-آنلی ݢیݢی</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>فرمت کرݨ ݢیݢی ݢیݢی ڈسک دی ساری ݢیݢی چھوڑݨ ݙیکھی، آپ ݢیݢی چھوڑݨ ݢیݢی ݢوݨ ݢیݢی؟ اس ݢیݢ کو نو تھوڑݨ ݢیݢی ݢوݨ ݢیݢی۔</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_pam.ts
+++ b/translations/dde-device-formatter_pam.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pam">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Nag-formatan ng maayos</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Nag-formatan ang hard drive, please wait...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Uri</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Etiketa</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Mabilis na Format</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Ang pag-format ay magpapalit ng lahat ng data sa hard drive.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Format</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Sulat</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Nag-format...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Tapos na</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Iwan</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Nagawa na ang iyong hard drive</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Nagawa ang pag-format sa aparato</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>I-format muli</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Sistemang Disk</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Naka-encrypt'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Volume'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Wala ang aparato</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Ang aparato ay lamang para basahin</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Ang pag-format ay magpapalit ng lahat ng data sa hard drive, sigurado ka bang gusto mong sulat? Hindi ito maaaring i-backup.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_pl.ts
+++ b/translations/dde-device-formatter_pl.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pl" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Format powiódł się</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formatowanie dysku, proszę czekać ...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Rodzaj</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etykieta</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Szybkie formatowanie</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Formatowanie spowoduje usunięcie wszystkich danych z dysku.</translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Format</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Kontynuuj</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatowanie...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Gotowe</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Wyjdź</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Podczas sformatowania dysk został usunięty</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Twój dysk został odłączony</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Nie udało się sformatować urządzenia</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Sformatuj ponownie</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Oświetlony dysk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>%1 szyfrowany</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>%1 pojemność</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Urządzenie nie istnieje</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Nie można sformatować urządzenia lokalnego</translation>
+        <translation>Urządzenie jest tylko do odczytu</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Formatowanie spowoduje usunięcie wszystkich danych z tego dysku. Czy na pewno chcesz kontynuować? Nie można go przywrócić.</translation>
     </message>

--- a/translations/dde-device-formatter_pt.ts
+++ b/translations/dde-device-formatter_pt.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pt" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formatação concluída</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>A formatar o disco, por favor aguarde...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etiqueta do volume</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Formatação Rápida</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>A formatação apagará todos os dados no disco.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>A formatar...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Concluído</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>O seu disco foi removido</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">O seu disco é removido ao formatar</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Erro ao formatar o dispositivo</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Reformatar</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Disco do sistema</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Encriptado</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Volume</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>Formatador de dispositivo DDE</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>O dispositivo não existe</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>O dispositivo é apenas de leitura</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Não é possível formatar o dispositivo local</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>A formatação apagará todos os dados neste disco, tem a certeza que deseja continuar? Isto não poderá ser restaurado.</translation>
     </message>

--- a/translations/dde-device-formatter_pt_BR.ts
+++ b/translations/dde-device-formatter_pt_BR.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pt_BR" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formatação bem-sucedida</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formatando o disco, aguarde...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Rótulo</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Formatação Rápida </translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>A formatação apagará todos os dados do disco.</translation>
     </message>
@@ -41,47 +43,43 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <location filename="../view/mainwindow.cpp" line="86"/>
         <source>Format</source>
         <translation>Formato</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatando...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Concluído</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Seu disco será removido ao formatar</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Erro ao formatar dispositivo</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Reformatar</translation>
     </message>
@@ -89,7 +87,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
@@ -97,17 +95,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Disco do Sistema</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Criptografado</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Volume</translation>
     </message>
@@ -115,24 +113,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>O dispositivo não existe</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>O dispositivo é somente leitura</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Não é possível formatar o dispositivo local</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>A formatação apagará todos os dados deste disco. Quer realmente continuar? Isso não poderá ser revertido.</translation>
     </message>

--- a/translations/dde-device-formatter_ro.ts
+++ b/translations/dde-device-formatter_ro.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ro">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Formatarea a reușit</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Formatarea discului, vă rugăm așteptați...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Tip</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Etichetă</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Formatare rapidă</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Formatarea va șterge toate datele de pe disc.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Formatare</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Continua</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Formatare...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Terminat</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Ieșire</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Discul dvs. a fost scos</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Eșecul formatării dispozitivului</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Reformatare</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Discul de sistem</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Criptat'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Volum'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Dispozitivul nu există</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Dispozitivul este doar pentru citire</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Formatarea va șterge toate datele de pe acest disc. Ești sigur că vrei să continui? Nu poate fi restaurat.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_ru.ts
+++ b/translations/dde-device-formatter_ru.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ru" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Отформатировано успешно</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Форматирование диска, пожалуйста ждите...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Метка</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Быстрое Форматирование</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Форматирование уничтожит всю информацию на диске.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Формат</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Продолжить</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Форматирование...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Выполнено</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Выход</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>Ваш диск был удален</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Ваш диск будет извлечен после форматирования</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Ошибка форматирования устройства</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Повтор форматирования</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Системный Диск</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Зашифровано</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Объём</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde устройство форматирования</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Устройство не существует</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Устройство только для чтения</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Не могу отформатировать локальное устройство</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Форматирование сотрет все данные на этом диске. Вы уверены, что хотите продолжить? Восстановление невозможно.</translation>
     </message>

--- a/translations/dde-device-formatter_sc.ts
+++ b/translations/dde-device-formatter_sc.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sc">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>التنسيق ناجح</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>يتم التنسيق القرص، من فضلك انتظر...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>نوع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>تنسيق سريع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>سيحذف التنسيق جميع البيانات الموجودة على القرص.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>التنسيق</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>استمر</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>يتم التنسيق...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>تم</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>خروج</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>تم إزالة قرصك</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>فشل التنسيق الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>إعادة التنسيق</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>موافق</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>القرص النظامي</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 مشفر'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 الحجم'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>الجهاز غير موجود</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>الجهاز فقط القراءة</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>سيحذف التنسيق جميع البيانات الموجودة على هذا القرص، هل أنت متأكد من أنك تريد الاستمرار؟ لا يمكن استعادة البيانات.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_si.ts
+++ b/translations/dde-device-formatter_si.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="si">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>වැරදි විය</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>ඩිස්කය සැකසේ, පිළිතුරු කරන්න...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>වර්ගය</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>ලෙබලය</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>සිතියම් සැකසීම</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>සැකසීම ඩිස්කයේ සියලුම දත්ත අල්ලා ගැනීමට අවශ්‍ය විය.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>සැකසීම</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>වැරදි කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>සැකසීම...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>සාර්ථක කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>අවසන් කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>ඔබගේ ඩිස්කය අතිරික්ත කරන්න</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>ඩිවයිසය සැකසීම සාර්ථක වී නොමැත</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>වැරදි සැකසීම</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>ඇක්කා</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>ස්යුස්ටම ඩිස්කය</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 ප්‍රමාණය අල්ලා ගත විය'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 වොලුමය'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde ඩිවයිස සැකසීම් අවයවය</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>ඩිවයිසය සොයා නොහැක</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>ඩිවයිසය ප්‍රකාශිත විය</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>සැකසීම මෙම ඩිස්කයේ සියලුම දත්ත අල්ලා ගැනීමට අවශ්‍ය විය. ඔබ එය වැරදි කරන්න අපේක්ෂිත වියද? එය අතිරික්ත කරන්න නොහැක.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_sk.ts
+++ b/translations/dde-device-formatter_sk.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sk" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sk">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formátovanie úspešné</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formátujem, prosím chvíľu počkajte...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Označenie</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Rýchle formátovanie</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Táto operácia zmaže všetky dáta z vášho zariadenia.</translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formátovanie</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Pokračovať</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formátujem...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Odísť</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Váš disk je odobratý pri formátovaní</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Vaš disk bol odpojený</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Formátovanie zariadenia zlyhalo</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Preformátovanie</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Systémový disk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 zašifrovaný'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 objem'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde formátor zariadenia</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Zariadenie neexistuje</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Neformátovať lokálne zariadenie</translation>
+        <translation>Zariadenie je len na čítanie</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Operácia formátovania zmaže všetky dáta z vášho disku, naozaj chcete pokračovať? Túto operáciu nemôžete vrátiť späť.</translation>
     </message>

--- a/translations/dde-device-formatter_sl.ts
+++ b/translations/dde-device-formatter_sl.ts
@@ -1,83 +1,84 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sl" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>Oblikovanje uspešno</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>Oblikovanje diska, prosím čekejte...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Vrsta</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Znamka</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>Hitro oblikovanje</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>Oblikovanje bo izbrisalo vse podatke na disku.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatiraj</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Nadaljuj</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatiram...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Končano</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Opusti</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Vaš disk je bil odstranjen med formatiranjem</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Vaš disk je bil odstranjen</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Oblikovanje naprave ni uspelo</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Ponovno formatiranje</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>V redu</translation>
     </message>
@@ -93,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Sistemski disk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>%1 šifriran</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>%1 volumen</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde oblikovalec naprave</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Naprava ne obstaja</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Ne morem formatirati lokalne naprave</translation>
+        <translation>Naprava je samo za branje</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>Oblikovanje bo izbrisalo vse podatke na tem disku, ali ste prepričani, da želite nadaljevati? Ne more biti obnovljeno.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_sq.ts
+++ b/translations/dde-device-formatter_sq.ts
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <location filename="../view/mainwindow.cpp" line="86"/>
+        <source>Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_sr.ts
+++ b/translations/dde-device-formatter_sr.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sr" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Успешно форматирање</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Форматирање диска, сачекајте...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Назив</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Брзо форматирање</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Форматирање ће обрисати све податке са диска.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Форматирај</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Настави</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Форматирање...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Завршено</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Напусти</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>Ваш диск је уклоњен</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Ваш диск је уклоњен током форматирања</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Неуспело форматирање уређаја</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Преформатирај</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>У реду</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Системски диск</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Шифровано</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Логички диск</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde форматер уређаја</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Уређај не постоји</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Уређај је само за читање</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Не могу да форматирам локални уређај</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Форматирањем се бришу сви подаци са диска. Заиста желите да наставите? Ова радња је неповратна.</translation>
     </message>

--- a/translations/dde-device-formatter_sv.ts
+++ b/translations/dde-device-formatter_sv.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="sv" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Formatering lyckades</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Formaterar disken, var god vänta...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Snabbformatera</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Formatering kommer radera all data på disken.</translation>
     </message>
@@ -41,43 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Formatera</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Fortsätt</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Formatterar...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Klart</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation>Din disk avlägsnas under formatering</translation>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Hårdisken har tagits bort</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>Det gick inte att formatera enheten</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Återformatera</translation>
     </message>
@@ -85,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -93,42 +94,43 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>Systemhårdisk</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Krypterad'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 Volym'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde enhetsformaterare</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Enheten existerar inte</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Kunde ej formatera lokal enhet</translation>
+        <translation>Enheten är skrivskyddad</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Formatering kommer radera all information på disken, är du säker du vill fortsätta? Detta går ej att ångra.</translation>
     </message>

--- a/translations/dde-device-formatter_sw.ts
+++ b/translations/dde-device-formatter_sw.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sw">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Formatu imeshindwa</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Inafanana diskilishi, tafadhali kuchukua...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Mara</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Mipango</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Formatu ya Kifalaki</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Formatu inaonyesha kufuta data zote katika diskilishi.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Formatu</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Jitokeza</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Inafanana...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Pumzike</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Kutoka</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Diskilishi yako inaonyesha kutoka</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Hakikishindwa kufanana na kifanana</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Kifanana tena</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Diskilishi ya Mazinga</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Imepelekwa'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Mipango'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde kifanana ya kifanana</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Kifanana hakuna</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Kifanana ni kifungu</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Formatu inaonyesha kufuta data zote katika diskilishi hii, tafadhali kuchukua kujitokeza? Hali inaonyesha kufuta.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_ta.ts
+++ b/translations/dde-device-formatter_ta.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ta" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ta">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>பார்மட்  வெற்றிகரமாக முடிந்தது </translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>பார்மட் செய்ய படுகிறது,காத்து இருகவும்...</translation>
     </message>
@@ -18,119 +20,119 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="104"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>வகைகள்</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="122"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>லேபிள்</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="131"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>மென்மையான வடிவமைக்க</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="148"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>வடிவமைப்பு இந்த டிஸ்கில் உள்ள அனைத்து பெட்டியையும் நீக்கும்</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
-        <translation type="unfinished"/>
+        <translation>வடிவமைக்க</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="161"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
-        <translation type="unfinished"/>
+        <translation>தொடர</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="166"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
-        <translation type="unfinished"/>
+        <translation>வடிவமைப்பு...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="191"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation>செய்து முடித்துள்ளேன்</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="197"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
-        <translation type="unfinished"/>
+        <translation>முடிக்க</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="198"/>
-        <source>Your disk is removed when formatting</source>
-        <translation type="unfinished"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>உங்கள் டிஸ்க் நீக்கப்பட்டுள்ளது</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="201"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>உபகரணத்தை வடிவமைக்க வேண்டும்</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="202"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
-        <translation type="unfinished"/>
+        <translation>மீண்டும் வடிவமைக்க</translation>
     </message>
 </context>
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation>சரி</translation>
     </message>
 </context>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>முதல் டிஸ்க்</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 பாதுகாக்கப்பட்டுள்ளது'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 பகுதி'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="112"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde உபகரணம் வடிவமைப்பு</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
-        <translation type="unfinished"/>
+        <translation>உபகரணம் இல்லை</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="121"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="unfinished"/>
+        <translation>உபகரணம் மட்டுமே படிக்க முடியும்</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>இந்த டிஸ்கில் உள்ள அனைத்து தகவல்களும் நீக்கப்படும், தொடர விரும்புகிறீர்களா? இது மீட்டருவதற்கு முடியாது.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_th.ts
+++ b/translations/dde-device-formatter_th.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="th">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>การจัดรูปแบบสำเร็จ</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>กำลังจัดรูปแบบแผ่นดิสก์ กรุณารอสักครู่...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>ประเภท</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>ชื่อ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>การจัดรูปแบบเร็ว</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>การจัดรูปแบบจะลบข้อมูลทั้งหมดบนแผ่นดิสก์</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>จัดรูปแบบ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>ดำเนินการต่อ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>กำลังจัดรูปแบบ...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>เสร็จสิ้น</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>ออก</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>แผ่นดิสก์ของคุณถูกถอดออกแล้ว</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>ไม่สามารถจัดรูปแบบอุปกรณ์ได้</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>จัดรูปแบบใหม่</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>ตกลง</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>แผ่นดิสก์ระบบ</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 ถูกเข้ารหัส'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 ชื่อแผ่น'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>อุปกรณ์ไม่มีอยู่</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>อุปกรณ์นี้อยู่ในโหมดอ่านเท่านั้น</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>การจัดรูปแบบจะลบข้อมูลทั้งหมดบนแผ่นดิสก์นี้ คุณแน่ใจว่าต้องการดำเนินการต่อหรือไม่? ข้อมูลจะไม่สามารถกู้คืนได้</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_tr.ts
+++ b/translations/dde-device-formatter_tr.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="tr" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Biçimlendirme başarılı</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Disk biçimlendirme için lütfen bekleyiniz...</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Tür</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Hızlı Biçimlendirme</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>Biçimlendirme diskteki tüm verileri siler.</translation>
     </message>
@@ -41,47 +43,42 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>Biçimlendir</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Devam</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Biçimlendiriliyor...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Tamam</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Çık</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>Diskiniz çıkarıldı</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">Biçimlendirme sırasında diskiniz kaldırılıyor</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Cihaz biçimlendirilemedi</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Yeniden biçimlendir</translation>
     </message>
@@ -89,7 +86,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>Tamam</translation>
     </message>
@@ -97,17 +94,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Sistem Diski</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 Şifreli</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 Birim</translation>
     </message>
@@ -115,24 +112,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde cihaz formatlayıcısı</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Cihaz yok</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Cihaz sadece salt okunur</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Yerel cihaz biçimlendirilemiyor</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>Biçimlendirme bu diskteki tüm verileri silecek, devam etmek istediğinizden emin misiniz? Geri yüklenemez.</translation>
     </message>

--- a/translations/dde-device-formatter_tzm.ts
+++ b/translations/dde-device-formatter_tzm.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tzm">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>التنسيق نجح</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>نعمل على التنسيق القرص، من فضلك انتظر...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>النوع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>الاسم</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>تنسيق سريع</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>التنسيق سيحذف جميع البيانات الموجودة على القرص.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>التنسيق</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>المتابعة</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>جاري التنسيق...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>تم</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>الخروج</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>قرصك قد تم إزالته</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>فشل التنسيق الجهاز</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>إعادة التنسيق</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>أوك</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>القرص النظامي</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 مشفر'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 وحّد</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde device formatter</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>الجهاز غير موجود</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>الجهاز قابل للقراءة فقط</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>التنسيق سيحذف جميع البيانات الموجودة على هذا القرص، هل أنت متأكد من أنك تريد المتابعة؟ لا يمكن استعادة البيانات.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_ug.ts
+++ b/translations/dde-device-formatter_ug.ts
@@ -1,95 +1,92 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ug" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
-        <translation type="unfinished"/>
+        <translation>سىفرمىت مۇۋەفەقىيەتلىك</translation>
     </message>
 </context>
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
-        <translation type="unfinished"/>
+        <translation>دېسکنى سىفرمىت قىلىۋاتىدۇ، كۈتۈرۈڭ...</translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>تىپى</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
-        <translation type="unfinished"/>
+        <translation>ئىسىم</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
-        <translation type="unfinished"/>
+        <translation>تېز سىفرمىت</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
-        <translation type="unfinished"/>
+        <translation>سىفرمىت بىر دېسکنى ئىشلەپ چىقىش ئىچىن بار دەتىنى سىلەيدۇ.</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
         <source>Format</source>
         <translation>فورمات</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
-        <translation type="unfinished"/>
+        <translation>دېۋام قىلىش</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
-        <translation type="unfinished"/>
+        <translation>سىفرمىت قىلىۋاتىدۇ...</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation>تەككىرلەندى</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
-        <translation type="unfinished"/>
+        <translation>چыقىش</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation>سىزنىڭ دېسكىڭىز ئۆچۈرۈلدى</translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
-        <translation type="unfinished"/>
+        <translation>تەسىرلىشىش ئۇچۇرلىقى</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
-        <translation type="unfinished"/>
+        <translation>تەسىرلىشىش</translation>
     </message>
 </context>
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>ھەئە</translation>
     </message>
@@ -97,44 +94,45 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
-        <translation type="unfinished"/>
+        <translation>سىستېم دېسكىسى</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
-        <translation type="unfinished"/>
+        <translation>'%1 سېنىمىشقا قىلىنغان'</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
-        <translation type="unfinished"/>
+        <translation>'%1 جايى'</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde تەسىرلىشىش چىقىرىشى</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
-        <translation type="unfinished"/>
+        <translation>تەسىرلىشىش چىقىرىشى ئۇچۇرلىقى</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="unfinished"/>
+        <translation>تەسىرلىشىش چىقىرىشى ئېنىق ئەسەرلىك</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
-        <translation type="unfinished"/>
+        <translation>سىفرمىت بىر دېسکنى ئىشلەپ چىقىش ئىچىن بار دەتىنى سىلەيدۇ، دېۋام قىلىشنى ئۇچۇرلىقى؟ ئۇ تەككىرلەنمەيدۇ.</translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-device-formatter_uk.ts
+++ b/translations/dde-device-formatter_uk.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="uk" version="2.1">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>FinishPage</name>
     <message>
-        <location filename="../view/finishpage.cpp" line="42"/>
+        <location filename="../view/finishpage.cpp" line="22"/>
         <source>Format successful</source>
         <translation>Успішне форматування</translation>
     </message>
@@ -10,7 +12,7 @@
 <context>
     <name>FormatingPage</name>
     <message>
-        <location filename="../view/formatingpage.cpp" line="47"/>
+        <location filename="../view/formatingpage.cpp" line="29"/>
         <source>Formatting the disk, please wait...</source>
         <translation>Форматуємо диск. Будь ласка, зачекайте…</translation>
     </message>
@@ -18,22 +20,22 @@
 <context>
     <name>MainPage</name>
     <message>
-        <location filename="../view/mainpage.cpp" line="119"/>
+        <location filename="../view/mainpage.cpp" line="99"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="137"/>
+        <location filename="../view/mainpage.cpp" line="117"/>
         <source>Label</source>
         <translation>Мітка</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="146"/>
+        <location filename="../view/mainpage.cpp" line="127"/>
         <source>Quick Format</source>
         <translation>Швидке форматування</translation>
     </message>
     <message>
-        <location filename="../view/mainpage.cpp" line="163"/>
+        <location filename="../view/mainpage.cpp" line="144"/>
         <source>Formatting will erase all data on the disk.</source>
         <translation>У результаті форматування усі дані з диска буде витерто.</translation>
     </message>
@@ -41,47 +43,43 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../view/mainwindow.cpp" line="88"/>
-        <location filename="../view/mainwindow.cpp" line="106"/>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <location filename="../view/mainwindow.cpp" line="86"/>
         <source>Format</source>
         <translation>Форматування</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="162"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>Продовжити</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="167"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>Форматуємо…</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="193"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>Виконано</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="199"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="200"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Your disk is removed when formatting</source>
-        <translation type="vanished">У процесі форматування ваш диск було вилучено</translation>
-    </message>
-    <message>
-        <location filename="../view/mainwindow.cpp" line="203"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>Не вдалося виконати форматування пристрою</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="204"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>Форматувати повторно</translation>
     </message>
@@ -89,7 +87,7 @@
 <context>
     <name>MessageDialog</name>
     <message>
-        <location filename="../dialogs/messagedialog.cpp" line="43"/>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
@@ -97,17 +95,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="55"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>Системний диск</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="59"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>Зашифровано %1</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="61"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>Том %1</translation>
     </message>
@@ -115,24 +113,25 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="90"/>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>Пристрою не існує</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="99"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>Пристрій призначено лише для читання</translation>
-    </message>
-    <message>
-        <source>Cannot format local device</source>
-        <translation type="vanished">Неможливо виконати форматування локального пристрою</translation>
     </message>
 </context>
 <context>
     <name>WarnPage</name>
     <message>
-        <location filename="../view/warnpage.cpp" line="43"/>
+        <location filename="../view/warnpage.cpp" line="23"/>
         <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
         <translation>У результаті форматування усі дані з диска буде витерто. Ви справді цього хочете. Відновити дані буде дуже важко.</translation>
     </message>

--- a/translations/dde-device-formatter_ur.ts
+++ b/translations/dde-device-formatter_ur.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ur">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>فرمتیں کامیابی سے کی گئی</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>ڈسک کی فرمتیں، انتظار کریں...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>ٹائپ</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>ٹیبل</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>کم سے کم فرمت</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>فرمت کرنا ڈسک پر تمام ڈیٹا مٹا دے گا۔</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>فرمت</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation> جاری رکھیں</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>فرمت کرنا...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>تمام</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>چھوڑ دیں</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>آپ کی ڈسک نکال لی گئی ہے</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>ڈیوائس کی فرمت کرنا کامیابی سے نہیں ہو سکی</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>دوبارہ فرمت</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>ٹھیک</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>سسٹم ڈسک</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 ایکسپریڈ' </translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 وولوم'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde ڈیوائس فرمتر</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>ڈیوائس موجود نہیں ہے</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>ڈیوائس کا کریڈ ہے</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>فرمت کرنا اس ڈسک پر تمام ڈیٹا مٹا دے گا، آپ کیا چاہتے ہیں کہ جاری رکھیں؟ یہ واپس نہیں کیا جا سکتا۔</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_vi.ts
+++ b/translations/dde-device-formatter_vi.ts
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="vi">
+<context>
+    <name>FinishPage</name>
+    <message>
+        <location filename="../view/finishpage.cpp" line="22"/>
+        <source>Format successful</source>
+        <translation>Định dạng thành công</translation>
+    </message>
+</context>
+<context>
+    <name>FormatingPage</name>
+    <message>
+        <location filename="../view/formatingpage.cpp" line="29"/>
+        <source>Formatting the disk, please wait...</source>
+        <translation>Đang định dạng đĩa, vui lòng chờ...</translation>
+    </message>
+</context>
+<context>
+    <name>MainPage</name>
+    <message>
+        <location filename="../view/mainpage.cpp" line="99"/>
+        <source>Type</source>
+        <translation>Loại</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="117"/>
+        <source>Label</source>
+        <translation>Nhãn</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="127"/>
+        <source>Quick Format</source>
+        <translation>Định dạng nhanh</translation>
+    </message>
+    <message>
+        <location filename="../view/mainpage.cpp" line="144"/>
+        <source>Formatting will erase all data on the disk.</source>
+        <translation>Định dạng sẽ xóa toàn bộ dữ liệu trên đĩa.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="68"/>
+        <source>Format</source>
+        <translation>Định dạng</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="250"/>
+        <source>Continue</source>
+        <translation>Tiếp tục</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="256"/>
+        <source>Formatting...</source>
+        <translation>Đang định dạng...</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="290"/>
+        <source>Done</source>
+        <translation>Hoàn tất</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="303"/>
+        <source>Quit</source>
+        <translation>Thoát</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="304"/>
+        <source>Your disk has been removed</source>
+        <translation>Ổ đĩa của bạn đã được gỡ ra</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="308"/>
+        <source>Failed to format the device</source>
+        <translation>Không thể định dạng thiết bị</translation>
+    </message>
+    <message>
+        <location filename="../view/mainwindow.cpp" line="309"/>
+        <source>Reformat</source>
+        <translation>Định dạng lại</translation>
+    </message>
+</context>
+<context>
+    <name>MessageDialog</name>
+    <message>
+        <location filename="../dialogs/messagedialog.cpp" line="23"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
+        <source>System Disk</source>
+        <translation>Ổ đĩa hệ thống</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
+        <source>%1 Encrypted</source>
+        <translation>'%1 Mã hóa'</translation>
+    </message>
+    <message>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
+        <source>%1 Volume</source>
+        <translation>'%1 Thể tích'</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="80"/>
+        <source>dde device formatter</source>
+        <translation>dde thiết bị định dạng</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="97"/>
+        <source>Device does not exist</source>
+        <translation>Thiết bị không tồn tại</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="107"/>
+        <source>The device is read-only</source>
+        <translation>Thiết bị chỉ đọc</translation>
+    </message>
+</context>
+<context>
+    <name>WarnPage</name>
+    <message>
+        <location filename="../view/warnpage.cpp" line="23"/>
+        <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+        <translation>Định dạng sẽ xóa toàn bộ dữ liệu trên ổ đĩa này, bạn có chắc muốn tiếp tục không? Dữ liệu không thể phục hồi.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-device-formatter_zh_CN.ts
+++ b/translations/dde-device-formatter_zh_CN.ts
@@ -49,37 +49,37 @@
         <translation>格式化</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="213"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>继续</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="218"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>格式化中……</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="244"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="254"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="255"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
         <translation>您的磁盘已被移除</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="258"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>格式化失败</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="259"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>重新格式化</translation>
     </message>
@@ -95,17 +95,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="38"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>系统盘</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="42"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 已加密</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="44"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 卷</translation>
     </message>
@@ -113,17 +113,17 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="68"/>
+        <location filename="../main.cpp" line="80"/>
         <source>dde device formatter</source>
         <translation>格式化工具</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="84"/>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>设备不存在</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="93"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>此设备为只读</translation>
     </message>

--- a/translations/dde-device-formatter_zh_HK.ts
+++ b/translations/dde-device-formatter_zh_HK.ts
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS language="zh_HK" version="2.1">
+    <context>
+        <name>FinishPage</name>
+        <message>
+            <location filename="../view/finishpage.cpp" line="22"/>
+            <source>Format successful</source>
+            <translation>格式化成功</translation>
+        </message>
+    </context>
+    <context>
+        <name>FormatingPage</name>
+        <message>
+            <location filename="../view/formatingpage.cpp" line="29"/>
+            <source>Formatting the disk, please wait...</source>
+            <translation>正在格式化，請稍候……</translation>
+        </message>
+    </context>
+    <context>
+        <name>MainPage</name>
+        <message>
+            <location filename="../view/mainpage.cpp" line="99"/>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <location filename="../view/mainpage.cpp" line="117"/>
+            <source>Label</source>
+            <translation>卷標</translation>
+        </message>
+        <message>
+            <location filename="../view/mainpage.cpp" line="127"/>
+            <source>Quick Format</source>
+            <translation>快速格式化</translation>
+        </message>
+        <message>
+            <location filename="../view/mainpage.cpp" line="144"/>
+            <source>Formatting will erase all data on the disk.</source>
+            <translation>執行格式化後會徹底清空該磁盤內容。</translation>
+        </message>
+    </context>
+    <context>
+        <name>MainWindow</name>
+        <message>
+            <location filename="../view/mainwindow.cpp" line="68"/>
+            <location filename="../view/mainwindow.cpp" line="86"/>
+            <source>Format</source>
+            <translation>格式化</translation>
+        </message>
+        <message>
+            <location filename="../view/mainwindow.cpp" line="250"/>
+            <source>Continue</source>
+            <translation>繼續</translation>
+        </message>
+        <message>
+            <location filename="../view/mainwindow.cpp" line="256"/>
+            <source>Formatting...</source>
+            <translation>格式化中……</translation>
+        </message>
+        <message>
+            <location filename="../view/mainwindow.cpp" line="290"/>
+            <source>Done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <location filename="../view/mainwindow.cpp" line="303"/>
+            <source>Quit</source>
+            <translation>退出</translation>
+        </message>
+        <message>
+            <location filename="../view/mainwindow.cpp" line="304"/>
+            <source>Your disk has been removed</source>
+            <translation>您的磁盤已被移除</translation>
+        </message>
+        <message>
+            <location filename="../view/mainwindow.cpp" line="308"/>
+            <source>Failed to format the device</source>
+            <translation>格式化失敗</translation>
+        </message>
+        <message>
+            <location filename="../view/mainwindow.cpp" line="309"/>
+            <source>Reformat</source>
+            <translation>重新格式化</translation>
+        </message>
+    </context>
+    <context>
+        <name>MessageDialog</name>
+        <message>
+            <location filename="../dialogs/messagedialog.cpp" line="23"/>
+            <source>OK</source>
+            <translation>確定</translation>
+        </message>
+    </context>
+    <context>
+        <name>QCoreApplication</name>
+        <message>
+            <location filename="../utils/udisksutils.cpp" line="40"/>
+            <source>System Disk</source>
+            <translation>系統盤</translation>
+        </message>
+        <message>
+            <location filename="../utils/udisksutils.cpp" line="46"/>
+            <source>%1 Encrypted</source>
+            <translation>%1 已加密</translation>
+        </message>
+        <message>
+            <location filename="../utils/udisksutils.cpp" line="50"/>
+            <source>%1 Volume</source>
+            <translation>%1 卷</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../main.cpp" line="80"/>
+            <source>dde device formatter</source>
+            <translation>格式化工具</translation>
+        </message>
+        <message>
+            <location filename="../main.cpp" line="97"/>
+            <source>Device does not exist</source>
+            <translation>設備不存在</translation>
+        </message>
+        <message>
+            <location filename="../main.cpp" line="107"/>
+            <source>The device is read-only</source>
+            <translation>此設備為只讀</translation>
+        </message>
+    </context>
+    <context>
+        <name>WarnPage</name>
+        <message>
+            <location filename="../view/warnpage.cpp" line="23"/>
+            <source>Formatting will erase all data on this disk, are you sure you want to continue? It cannot be restored.</source>
+            <translation>格式化操作將會清除磁盤上所有內容，確定繼續操作？該操作無法恢復。</translation>
+        </message>
+    </context>
+</TS>

--- a/translations/dde-device-formatter_zh_TW.ts
+++ b/translations/dde-device-formatter_zh_TW.ts
@@ -49,37 +49,37 @@
         <translation>格式化</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="213"/>
+        <location filename="../view/mainwindow.cpp" line="250"/>
         <source>Continue</source>
         <translation>繼續</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="218"/>
+        <location filename="../view/mainwindow.cpp" line="256"/>
         <source>Formatting...</source>
         <translation>正在格式化…</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="244"/>
+        <location filename="../view/mainwindow.cpp" line="290"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="254"/>
+        <location filename="../view/mainwindow.cpp" line="303"/>
         <source>Quit</source>
         <translation>離開</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="255"/>
+        <location filename="../view/mainwindow.cpp" line="304"/>
         <source>Your disk has been removed</source>
         <translation>您的磁盤已被移除</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="258"/>
+        <location filename="../view/mainwindow.cpp" line="308"/>
         <source>Failed to format the device</source>
         <translation>格式化失敗</translation>
     </message>
     <message>
-        <location filename="../view/mainwindow.cpp" line="259"/>
+        <location filename="../view/mainwindow.cpp" line="309"/>
         <source>Reformat</source>
         <translation>重新格式化</translation>
     </message>
@@ -95,17 +95,17 @@
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="38"/>
+        <location filename="../utils/udisksutils.cpp" line="40"/>
         <source>System Disk</source>
         <translation>系統盤</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="42"/>
+        <location filename="../utils/udisksutils.cpp" line="46"/>
         <source>%1 Encrypted</source>
         <translation>%1 已加密</translation>
     </message>
     <message>
-        <location filename="../utils/udisksutils.cpp" line="44"/>
+        <location filename="../utils/udisksutils.cpp" line="50"/>
         <source>%1 Volume</source>
         <translation>%1 卷</translation>
     </message>
@@ -113,17 +113,17 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../main.cpp" line="68"/>
+        <location filename="../main.cpp" line="80"/>
         <source>dde device formatter</source>
         <translation>格式化工具</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="84"/>
+        <location filename="../main.cpp" line="97"/>
         <source>Device does not exist</source>
         <translation>裝置不存在</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="93"/>
+        <location filename="../main.cpp" line="107"/>
         <source>The device is read-only</source>
         <translation>此設備爲只讀</translation>
     </message>


### PR DESCRIPTION
update translations

Log: update translations

## Summary by Sourcery

Update and complete translation resources for dde-device-formatter by standardizing TS file headers, synchronizing source references, and filling in missing strings across numerous locales.

Enhancements:
- Standardize XML headers and TS tags (encoding, version, language) in all translation files.
- Synchronize source file line numbers in TS entries after code updates.
- Fill in previously missing translations for UI strings across many languages (e.g., Malayalam, Uyghur, Arabic, etc.).
- Add new translation templates for additional locales (e.g., sq, zh_HK, ku).
- Replace unfinished placeholders with actual translations and remove obsolete entries.