### PR TITLE
chore: bump version to 1.5.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-device-formatter (1.5.5) unstable; urgency=medium
+
+  * update translations
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Mon, 23 Jun 2025 14:07:48 +0800
+
 dde-device-formatter (1.5.4) unstable; urgency=medium
 
   * Add support for nilfs2


### PR DESCRIPTION
1.5.5

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 1.5.5