### PR TITLE
fix: update .gitignore and modify formatDevice function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.user
+.cursor/*
+.cache/*
+.claude/*
+build/*

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-device-formatter (0.0.1.18) unstable; urgency=medium
+
+  * take disk ownership after formatted.
+  * 
+  * 
+
+ -- XuShitong <xushitong@uniontech.com>  Sat, 26 Jul 2025 15:52:40 +0800
+
 dde-device-formatter (0.0.1.17) unstable; urgency=medium
 
   * Auto mount after device been formatted.

--- a/view/mainwindow.cpp
+++ b/view/mainwindow.cpp
@@ -187,7 +187,7 @@ void MainWindow::formatDevice()
                 return;
             }
         }
-        QVariantMap opt = { { "label", m_mainPage->getLabel() } };
+        QVariantMap opt = { { "label", m_mainPage->getLabel() }, { "take-ownership", true } };
         if (m_mainPage->shouldErase()) opt["erase"] = "zero";
         blk->format(m_mainPage->getSelectedFs(), opt);
         QDBusError lastError = blk->lastError();


### PR DESCRIPTION
Updated .gitignore to exclude additional directories: .cursor, .cache, .claude, and build. Modified the formatDevice function in mainwindow.cpp to include a new option 'take-ownership' set to true in the QVariantMap.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-325935.html
