### PR TITLE
feat: add ownership option to device formatting

### DIFF
--- a/view/mainwindow.cpp
+++ b/view/mainwindow.cpp
@@ -219,7 +219,7 @@ void MainWindow::formatDevice()
             qDebug() << "MainWindow: Device is not mounted, proceeding with format";
         }
         
-        QVariantMap opt = { { "label", m_mainPage->getLabel() } };
+        QVariantMap opt = { { "label", m_mainPage->getLabel() }, { "take-ownership", true } };
         if (m_mainPage->shouldErase()) opt["erase"] = "zero";
         blk->format(m_mainPage->getSelectedFs(), opt);
         QDBusError lastError = blk->lastError();


### PR DESCRIPTION
- Updated the device formatting options to include a new parameter "take-ownership" set to true.
- This enhancement allows for better management of device ownership during formatting.

Log: Added ownership option to device formatting.

Bug: https://pms.uniontech.com/bug-view-325935.html
